### PR TITLE
Add injection handler and console logging

### DIFF
--- a/cplex/latest/db.py
+++ b/cplex/latest/db.py
@@ -47,3 +47,17 @@ def get_all_uuids() -> list:
     except Exception as e:
         print(f"❌ Błąd pobierania UUIDów: {e}")
         return []
+
+
+def get_client(uuid: str) -> dict:
+    """Return full client row for the given uuid."""
+    try:
+        response = supabase.table("clients").select("*").eq("uuid", uuid).limit(1).execute()
+        if response.data:
+            return response.data[0]
+        else:
+            print(f"⚠️ Nie znaleziono klienta: {uuid}")
+            return {}
+    except Exception as e:
+        print(f"❌ Błąd pobierania klienta {uuid}: {e}")
+        return {}

--- a/cplex/latest/extension_chrome/content.js
+++ b/cplex/latest/extension_chrome/content.js
@@ -1,101 +1,143 @@
-﻿// ✅ content.js
-const MESSAGE_TYPES = {
-  CLICK: "click",
-  CHECK: "check",
-  AMOUNT: "amount",
-  REFRESH: "refresh",
-  CLOSE_POPUP: "closepopup"
-};
-
-const RESPONSE_KEYS = {
-  BUTTON_STATUS: "BUTTON_STATUS",
-  QUANTIFIABLE_AMOUNT: "QUANTIFIABLE_AMOUNT",
-  POPUP_CLOSED: "POPUP_CLOSED"
-};
-
-function closePopupIfExists() {
-  const popup = document.querySelector('.popup-con');
-  const closeButton = document.querySelector('.cross i.van-icon-cross');
-  if (popup && closeButton) {
-    closeButton.click();
-    return true;
+// ✅ content.js
+(() => {
+  if (window.__cplexLoaded) {
+    console.log('ℹ️ content.js already loaded');
+    return;
   }
-  return false;
-}
+  window.__cplexLoaded = true;
+  console.log('🚀 content.js initialized');
 
-function handlePopupOnLoad() {
-  let attempts = 0;
-  const maxAttempts = 20;
-  const interval = 1000;
-  const initialDelay = 5000;
-
-  const checkAndClose = () => {
-    attempts++;
-    if (closePopupIfExists()) return;
-    if (attempts < maxAttempts) setTimeout(checkAndClose, interval);
+  const MESSAGE_TYPES = {
+    CLICK: "click",
+    CHECK: "check",
+    AMOUNT: "amount",
+    REFRESH: "refresh",
+    CLOSE_POPUP: "closepopup"
   };
 
-  setTimeout(checkAndClose, initialDelay);
-}
+  const RESPONSE_KEYS = {
+    BUTTON_STATUS: "BUTTON_STATUS",
+    QUANTIFIABLE_AMOUNT: "QUANTIFIABLE_AMOUNT",
+    POPUP_CLOSED: "POPUP_CLOSED"
+  };
 
-function sendResponse(type, value) {
-  chrome.runtime.sendMessage({
-    type: "client_response",
-    payload: { type, value }
-  });
-}
+  function closePopupIfExists() {
+    const popup = document.querySelector('.popup-con');
+    const closeButton = document.querySelector('.cross i.van-icon-cross');
+    if (popup && closeButton) {
+      console.log('🔍 Znaleziono popup, próbuję go zamknąć...');
+      closeButton.click();
+      console.log('✅ Kliknięto przycisk zamykania popupu');
+      return true;
+    }
+    console.log('ℹ️ Popup nie znaleziony lub już zamknięty');
+    return false;
+  }
 
-const handlers = {
-  [MESSAGE_TYPES.CLICK]: () => {
-    const btn = document.querySelector(".start-btn");
-    if (btn && btn.offsetParent !== null) btn.click();
-  },
-  [MESSAGE_TYPES.CHECK]: () => {
-    const btn = document.querySelector(".start-btn");
-    const status = !btn ? "missing" : btn.offsetParent === null ? "hidden" : "visible";
-    sendResponse(RESPONSE_KEYS.BUTTON_STATUS, status);
-  },
-  [MESSAGE_TYPES.AMOUNT]: () => {
+  function handlePopupOnLoad() {
     let attempts = 0;
-    const maxAttempts = 10;
+    const maxAttempts = 20;
     const interval = 1000;
-    const checkAmount = () => {
+    const initialDelay = 5000;
+
+    const checkAndClose = () => {
       attempts++;
-      const nameElem = Array.from(document.querySelectorAll(".item .name"))
-        .find(el => el.textContent.includes("Today's Quantifiable Amount"));
-      const parent = nameElem?.closest(".item");
-      const valueElem = parent?.querySelector(".val");
-      const amountText = valueElem?.textContent.trim() || "UNKNOWN";
-      if (amountText !== "UNKNOWN" && !amountText.startsWith("0 /")) {
-        sendResponse(RESPONSE_KEYS.QUANTIFIABLE_AMOUNT, amountText);
-      } else if (attempts < maxAttempts) {
-        setTimeout(checkAmount, interval);
+      console.log(`🔍 Próba ${attempts}/${maxAttempts} zamknięcia popupu...`);
+      if (closePopupIfExists()) {
+        console.log('✅ Popup zamknięty pomyślnie!');
+        return;
+      }
+      if (attempts < maxAttempts) {
+        setTimeout(checkAndClose, interval);
       } else {
-        sendResponse(RESPONSE_KEYS.QUANTIFIABLE_AMOUNT, amountText);
+        console.log('⏰ Osiągnięto maksymalną liczbę prób zamykania popupu');
       }
     };
-    checkAmount();
-  },
-  [MESSAGE_TYPES.REFRESH]: () => location.reload(),
-  [MESSAGE_TYPES.CLOSE_POPUP]: () => {
-    const result = closePopupIfExists();
-    sendResponse(RESPONSE_KEYS.POPUP_CLOSED, result ? "success" : "failed");
-  }
-};
 
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === "ws_message") {
-    try {
-      const data = JSON.parse(message.payload);
-      if (data.command && handlers[data.command]) handlers[data.command]();
-    } catch (e) {
-      console.warn("Nieprawidłowa wiadomość z WebSocket:", message.payload);
+    setTimeout(checkAndClose, initialDelay);
+  }
+
+  function sendResponse(type, value) {
+    console.log('📤 sending response', { type, value });
+    chrome.runtime.sendMessage({
+      type: "client_response",
+      payload: { type, value }
+    });
+  }
+
+  const handlers = {
+    [MESSAGE_TYPES.CLICK]: () => {
+      const btn = document.querySelector(".start-btn");
+      if (btn && btn.offsetParent !== null) {
+        btn.click();
+        console.log('✅ Kliknięto przycisk .start-btn');
+      } else {
+        console.warn('❌ Przycisk .start-btn niedostępny');
+      }
+    },
+    [MESSAGE_TYPES.CHECK]: () => {
+      const btn = document.querySelector(".start-btn");
+      const status = !btn ? "missing" : btn.offsetParent === null ? "hidden" : "visible";
+      sendResponse(RESPONSE_KEYS.BUTTON_STATUS, status);
+      console.log('🧪 Status przycisku:', status);
+    },
+    [MESSAGE_TYPES.AMOUNT]: () => {
+      let attempts = 0;
+      const maxAttempts = 10;
+      const interval = 1000;
+      const checkAmount = () => {
+        attempts++;
+        console.log(`🔁 Próba ${attempts}: sprawdzam amount...`);
+        const nameElem = Array.from(document.querySelectorAll(".item .name"))
+          .find(el => el.textContent.includes("Today's Quantifiable Amount"));
+        const parent = nameElem?.closest(".item");
+        const valueElem = parent?.querySelector(".val");
+        const amountText = valueElem?.textContent.trim() || "UNKNOWN";
+        console.log('   znaleziono amount:', amountText);
+        if (amountText !== "UNKNOWN" && !amountText.startsWith("0 /")) {
+          sendResponse(RESPONSE_KEYS.QUANTIFIABLE_AMOUNT, amountText);
+        } else if (attempts < maxAttempts) {
+          setTimeout(checkAmount, interval);
+        } else {
+          sendResponse(RESPONSE_KEYS.QUANTIFIABLE_AMOUNT, amountText);
+        }
+      };
+      checkAmount();
+    },
+    [MESSAGE_TYPES.REFRESH]: () => {
+      console.log('🔄 Odświeżanie strony...');
+      location.reload();
+    },
+    [MESSAGE_TYPES.CLOSE_POPUP]: () => {
+      const result = closePopupIfExists();
+      sendResponse(RESPONSE_KEYS.POPUP_CLOSED, result ? "success" : "failed");
+      if (result) {
+        console.log('✅ Popup zamknięty przez komendę');
+      } else {
+        console.log('❌ Nie udało się zamknąć popupu');
+      }
     }
-  }
-});
+  };
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', handlePopupOnLoad);
-} else {
-  handlePopupOnLoad();
-}
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === "ws_message") {
+      try {
+        const data = JSON.parse(message.payload);
+        if (data.command && handlers[data.command]) {
+          console.log('📨 Otrzymano komendę:', data.command);
+          handlers[data.command]();
+        }
+      } catch (e) {
+        console.warn("Nieprawidłowa wiadomość z WebSocket:", message.payload);
+      }
+    } else if (message.type === "log") {
+      console.log(message.payload);
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', handlePopupOnLoad);
+  } else {
+    handlePopupOnLoad();
+  }
+})();

--- a/cplex/latest/init.sql
+++ b/cplex/latest/init.sql
@@ -2,11 +2,25 @@ drop table if exists clients;
 
 create table clients (
   id uuid primary key default gen_random_uuid(),
+
   uuid text unique not null,
   alias text,
+
   is_enabled boolean default true,
   running boolean default false,
   amount real,
   state text,
-  created_at timestamp default now()
+
+  -- Informacje o operacji "start_morning"
+  last_start_morning_date date,
+  start_morning_status text,
+  start_morning_clicks int,
+  balance_before text,
+  balance_after text,
+
+  refreshed_today boolean default false,
+  error_message text,
+
+  created_at timestamp default now(),
+  updated_at timestamp default now()
 );

--- a/cplex/latest/main.py
+++ b/cplex/latest/main.py
@@ -17,7 +17,7 @@ morning_tasks = {}
 
 async def send_command(target_uuid: str, command: str):
     ws = connections.get(target_uuid)
-    if ws and ws.open:
+    if ws and not ws.closed:
         await ws.send(json.dumps({"command": command}))
         print(f"➡️ Sent {command} to {target_uuid}")
     else:

--- a/cplex/latest/main.py
+++ b/cplex/latest/main.py
@@ -1,11 +1,91 @@
 import asyncio
 import json
+import re
+from datetime import date
 import websockets
-from db import add_user_if_not_exists
-from User import User
+from db import (
+    add_user_if_not_exists,
+    update_client_state,
+    get_client_state,
+    get_client,
+)
 
 connections = {}  # uuid -> websocket
 admin_clients = set()  # websockety adminów
+morning_tasks = {}
+
+
+async def send_command(target_uuid: str, command: str):
+    ws = connections.get(target_uuid)
+    if ws and ws.open:
+        await ws.send(json.dumps({"command": command}))
+        print(f"➡️ Sent {command} to {target_uuid}")
+    else:
+        print(f"⚠️ {target_uuid} not connected")
+
+
+def process_client_data(uuid: str, msg_type: str, value: str):
+    updates = {}
+    if msg_type == "QUANTIFIABLE_AMOUNT" or msg_type.lower() == "quantifiable_amount":
+        match = re.search(r"[\d.]+", value or "")
+        if match:
+            updates["amount"] = float(match.group())
+    elif msg_type == "BUTTON_STATUS" or msg_type.lower() == "button_status":
+        updates["button_status"] = value.lower() if isinstance(value, str) else value
+    if updates:
+        update_client_state(uuid, updates)
+
+
+async def run_start_morning(uuid: str):
+    state = get_client(uuid)
+    today = date.today().isoformat()
+    if state.get("last_start_morning_date") == today:
+        print(f"⏭️ {uuid} already processed today")
+        update_client_state(uuid, {"start_morning_status": "skipped"})
+        return
+
+    update_client_state(
+        uuid,
+        {
+            "running": True,
+            "start_morning_clicks": 0,
+            "last_start_morning_date": today,
+            "start_morning_status": "running",
+        },
+    )
+
+    await send_command(uuid, "refresh")
+    await asyncio.sleep(10)
+    await send_command(uuid, "amount")
+    await asyncio.sleep(5)
+
+    state = get_client_state(uuid)
+    amount = state.get("amount")
+    update_client_state(uuid, {"balance_before": str(amount) if amount is not None else None})
+
+    clicks = 0
+    while clicks < 4 and amount not in (None, 0, 0.0) and not str(amount).startswith("0"):
+        await send_command(uuid, "check")
+        await asyncio.sleep(5)
+        state = get_client_state(uuid)
+        if state.get("button_status") == "visible":
+            await send_command(uuid, "click")
+            clicks += 1
+            update_client_state(uuid, {"start_morning_clicks": clicks})
+        await asyncio.sleep(10)
+        await send_command(uuid, "amount")
+        await asyncio.sleep(5)
+        state = get_client_state(uuid)
+        amount = state.get("amount")
+
+    update_client_state(
+        uuid,
+        {
+            "running": False,
+            "start_morning_status": "success",
+            "balance_after": str(amount) if amount is not None else None,
+        },
+    )
 
 
 async def handler(websocket):
@@ -50,15 +130,29 @@ async def handler(websocket):
                         await websocket.send(json.dumps({"error": "Brakuje uuid lub command"}))
                         continue
 
-                    target_ws = connections.get(target_uuid)
-                    if target_ws:
-                        await target_ws.send(f"{target_uuid}::{command}")
-                        await websocket.send(json.dumps({"status": f"Komenda '{command}' wysłana do {target_uuid}"}))
-                    else:
-                        await websocket.send(json.dumps({"error": f"{target_uuid} nie jest połączony"}))
+                    if command == "start_morning":
+                        task = asyncio.create_task(run_start_morning(target_uuid))
+                        morning_tasks[target_uuid] = task
+                        await websocket.send(json.dumps({"status": f"Uruchomiono start_morning dla {target_uuid}"}))
+                        continue
+
+                    await send_command(target_uuid, command)
+                    await websocket.send(json.dumps({"status": f"Komenda '{command}' wysłana do {target_uuid}"}))
 
                 except Exception as e:
                     await websocket.send(json.dumps({"error": f"Błąd przetwarzania komendy: {str(e)}"}))
+                continue
+
+            # Obsługa wiadomości od klienta
+            if uuid and websocket in connections.values():
+                try:
+                    data = json.loads(message)
+                    msg_type = data.get("type")
+                    value = data.get("value")
+                    if msg_type:
+                        process_client_data(uuid, msg_type, value)
+                except Exception as e:
+                    print(f"⚠️ Niepoprawna wiadomość od {uuid}: {e}")
 
     except websockets.exceptions.ConnectionClosed:
         print(f"🔴 Rozłączono: {uuid or 'admin'}")


### PR DESCRIPTION
## Summary
- inject `content.js` from the service worker when Coinplex tabs load
- resend messages after injection to avoid 'receiving end does not exist'
- log actions from the content script for easier debugging

## Testing
- `python3 -m py_compile cplex/latest/main.py`
- `python3 -m py_compile cplex/latest/ws.py`
- `node --check cplex/latest/extension_chrome/background.js`
- `node --check cplex/latest/extension_chrome/content.js`


------
https://chatgpt.com/codex/tasks/task_e_6877541648888327acaa6d4238b43838